### PR TITLE
Fix scale-out failure in TLS mode

### DIFF
--- a/3.5/ubuntu22.04/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/ubuntu22.04/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -221,7 +221,7 @@ etcd_start_bg() {
 #   String
 ########################
 etcdctl_get_endpoints() {
-   echo "$ETCD_INITIAL_CLUSTER" | sed 's/^[^=]\+=http/http/g' |sed 's/,[^=]\+=/,/g'
+   echo "$ETCD_INITIAL_CLUSTER" | sed 's/^[^=]\+=http/http/g' |sed 's/,[^=]\+=/,/g' | sed 's/:2380/:2379/g'
 }
 
 ########################

--- a/3.5/ubuntu22.04/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/ubuntu22.04/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -220,7 +220,7 @@ etcd_start_bg() {
 # Returns:
 #   String
 ########################
-etcdctl_get_peer_endpoints() {
+etcdctl_get_endpoints() {
    echo "$ETCD_INITIAL_CLUSTER" | sed 's/^[^=]\+=http/http/g' |sed 's/,[^=]\+=/,/g'
 }
 
@@ -485,7 +485,7 @@ recalculate_initial_cluster() {
     local domain host member_host member_port member_id port scheme
 
     if is_boolean_yes "$ETCD_ON_K8S"; then
-        read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_peer_endpoints)")"
+        read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_endpoints)")"
         # This piece of code assumes this container is used on a K8s environment
         # where etcd members are part of a statefulset that uses a headless service
         # to create a unique FQDN per member. Under these circumstances, the

--- a/3.5/ubuntu22.04/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/3.5/ubuntu22.04/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -216,12 +216,36 @@ etcd_start_bg() {
 # Globals:
 #   ETCD_*
 # Arguments:
-#   $1 - exclude current member from the list (default: false)
+#   None
 # Returns:
 #   String
 ########################
-etcdctl_get_endpoints() {
-   echo "$ETCD_INITIAL_CLUSTER" | sed 's/^[^=]\+=http/http/g' |sed 's/,[^=]\+=/,/g' | sed 's/:2380/:2379/g'
+etcdctl_get_peer_endpoints() {
+   echo "$ETCD_INITIAL_CLUSTER" | sed 's/^[^=]\+=http/http/g' |sed 's/,[^=]\+=/,/g'
+}
+
+########################
+# Obtain client endpoints to connect when running 'ectdctl'
+# Globals:
+#   ETCD_*
+# Arguments:
+#   None
+# Returns:
+#   String
+########################
+etcdctl_get_client_endpoints() {
+    # Extract peer port from ETCD_LISTEN_PEER_URLS (first URL)
+    local first_peer_url=$(echo "$ETCD_LISTEN_PEER_URLS" | cut -d',' -f1)
+    local peer_port="${first_peer_url##*:}"
+
+    # Extract client port from ETCD_ADVERTISE_CLIENT_URLS (first URL)
+    local first_client_url=$(echo "$ETCD_ADVERTISE_CLIENT_URLS" | cut -d',' -f1)
+    local client_port="${first_client_url##*:}"
+
+    echo "$ETCD_INITIAL_CLUSTER" \
+        | sed 's/^[^=]\+=http/http/g' \
+        | sed 's/,[^=]\+=/,/g' \
+        | sed "s/:${peer_port}/:${client_port}/g"
 }
 
 ########################
@@ -261,7 +285,7 @@ etcd_store_member_id() {
     info "Obtaining cluster member ID"
     etcd_start_bg
     read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
-    is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_endpoints)")
+    is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_client_endpoints)")
     if retry_while "etcdctl ${extra_flags[*]} member list" >/dev/null 2>&1; then
         while [[ ! -s "${ETCD_DATA_DIR}/member_id" ]]; do
             # We use 'stdbuf' to ensure memory buffers are flushed to disk
@@ -290,7 +314,7 @@ etcd_configure_rbac() {
     ! is_etcd_running && etcd_start_bg
     read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
 
-    is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_endpoints)")
+    is_boolean_yes "$ETCD_ON_K8S" && extra_flags+=("--endpoints=$(etcdctl_get_client_endpoints)")
     if retry_while "etcdctl ${extra_flags[*]} member list" >/dev/null 2>&1; then
         debug_execute etcdctl "${extra_flags[@]}" user add root --interactive=false <<<"$ETCD_ROOT_PASSWORD"
         debug_execute etcdctl "${extra_flags[@]}" user grant-role root root
@@ -353,7 +377,7 @@ get_etcd_active_endpoints() {
     local -a endpoints_array=()
     local host port
 
-    is_boolean_yes "$ETCD_ON_K8S" && read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_endpoints)")"
+    is_boolean_yes "$ETCD_ON_K8S" && read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_client_endpoints)")"
     local -r cluster_size=${#endpoints_array[@]}
     read -r -a advertised_array <<<"$(tr ',;' ' ' <<<"$ETCD_ADVERTISE_CLIENT_URLS")"
     host="$(parse_uri "${advertised_array[0]}" "host")"
@@ -393,7 +417,7 @@ is_healthy_etcd_cluster() {
     local -a endpoints_array=()
     local host port
 
-    is_boolean_yes "$ETCD_ON_K8S" && read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_endpoints)")"
+    is_boolean_yes "$ETCD_ON_K8S" && read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_client_endpoints)")"
     local -r cluster_size=${#endpoints_array[@]}
     read -r -a advertised_array <<<"$(tr ',;' ' ' <<<"$ETCD_ADVERTISE_CLIENT_URLS")"
     host="$(parse_uri "${advertised_array[0]}" "host")"
@@ -461,7 +485,7 @@ recalculate_initial_cluster() {
     local domain host member_host member_port member_id port scheme
 
     if is_boolean_yes "$ETCD_ON_K8S"; then
-        read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_endpoints)")"
+        read -r -a endpoints_array <<<"$(tr ',;' ' ' <<<"$(etcdctl_get_peer_endpoints)")"
         # This piece of code assumes this container is used on a K8s environment
         # where etcd members are part of a statefulset that uses a headless service
         # to create a unique FQDN per member. Under these circumstances, the


### PR DESCRIPTION
**Description:**
The issue was observed during the scale-up of an etcd cluster when TLS is enabled. The etcdctl_get_endpoints function incorrectly used peer ports (from ETCD_INITIAL_CLUSTER) when generating endpoints for etcdctl health checks. Since etcdctl communicates over client ports, the health check failed, leading to the endpoint list being empty and ultimately causing the scale-up to fail.

**Fix**
To resolve this, a new function named etcdctl_get_client_endpoints was introduced. This function:

- Dynamically extracts the peer port from ETCD_LISTEN_PEER_URLS.
- Dynamically extracts the client port from ETCD_ADVERTISE_CLIENT_URLS.
- Replaces the peer port with the client port in the ETCD_INITIAL_CLUSTER-based endpoint list.

All references that previously used `etcdctl_get_endpoints` for etcdctl operations were updated to use the new `etcdctl_get_client_endpoints` function to ensure client endpoints are used correctly, especially in TLS scenarios.

**Applicable issues**
Fixes #17 

**Benefits**

- Ensures correct endpoint resolution for etcdctl, especially in TLS-enabled environments.
- Fixes scale-up failures caused by incorrect health check endpoint usage.
- Supports custom ports for both client and peer configurations.
- Improves reliability and flexibility of etcd operations under secure configurations.

NOTE: Please squash commits on merge to keep history clean.
