### PR TITLE
bump etcd version to v3.5.25

### DIFF
--- a/3.5/ubuntu22.04/Dockerfile
+++ b/3.5/ubuntu22.04/Dockerfile
@@ -7,10 +7,10 @@ LABEL maintainer="Team DevOps of Zilliz <devops@zilliz.com" \
       org.opencontainers.image.description="Application packaged by Bitnami, polished by zilliztech" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.source="https://github.com/milvus-io/bitnami-docker-etcd" \
-      org.opencontainers.image.ref.name="3.5.23-r1" \
+      org.opencontainers.image.ref.name="3.5.25-r1" \
       org.opencontainers.image.title="etcd" \
       org.opencontainers.image.vendor="VMware, Inc." \
-      org.opencontainers.image.version="3.5.23-r1"
+      org.opencontainers.image.version="3.5.25-r1"
 
 ENV HOME="/" \
     OS_ARCH_RAW="${TARGETARCH}" \
@@ -23,13 +23,13 @@ SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 RUN install_packages ca-certificates curl procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     OS_ARCH=`echo ${OS_ARCH_RAW}| sed 's|/|-|'` && \
-    curl -SsLf https://github.com/etcd-io/etcd/releases/download/v3.5.23/etcd-v3.5.23-${OS_ARCH}.tar.gz -O && \
-    tar -zxf "etcd-v3.5.23-${OS_ARCH}.tar.gz" && \
+    curl -SsLf https://github.com/etcd-io/etcd/releases/download/v3.5.25/etcd-v3.5.25-${OS_ARCH}.tar.gz -O && \
+    tar -zxf "etcd-v3.5.25-${OS_ARCH}.tar.gz" && \
     mkdir -p /opt/bitnami/etcd/bin && \
-    mv ./etcd-v3.5.23-${OS_ARCH}/etcd /opt/bitnami/etcd/bin/etcd && \
-    mv ./etcd-v3.5.23-${OS_ARCH}/etcdctl /opt/bitnami/etcd/bin/etcdctl && \
-    mv ./etcd-v3.5.23-${OS_ARCH}/etcdutl /opt/bitnami/etcd/bin/etcdutl && \
-    rm -rf "etcd-v3.5.23-${OS_ARCH}.tar.gz"
+    mv ./etcd-v3.5.25-${OS_ARCH}/etcd /opt/bitnami/etcd/bin/etcd && \
+    mv ./etcd-v3.5.25-${OS_ARCH}/etcdctl /opt/bitnami/etcd/bin/etcdctl && \
+    mv ./etcd-v3.5.25-${OS_ARCH}/etcdutl /opt/bitnami/etcd/bin/etcdutl && \
+    rm -rf "etcd-v3.5.25-${OS_ARCH}.tar.gz"
 RUN cd /tmp/bitnami/pkg/cache/ && \
     OS_ARCH=`echo ${OS_ARCH_RAW}| sed 's|/|_|'` && \
     if [ ! -f "yq_${OS_ARCH}.tar.gz" ]; then \
@@ -44,7 +44,7 @@ RUN chmod g+rwX /opt/bitnami
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/etcd/postunpack.sh
-ENV APP_VERSION="3.5.23" \
+ENV APP_VERSION="3.5.25" \
     BITNAMI_APP_NAME="etcd" \
     ETCDCTL_API="3" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/etcd/bin:$PATH"


### PR DESCRIPTION
This pull request updates the etcd version used in the `3.5/ubuntu22.04/Dockerfile` from 3.5.23 to 3.5.25. The changes ensure that the Docker image references, downloads, and environment variables are all aligned with the new version.

Version upgrade:

* Updated `org.opencontainers.image.ref.name` and `org.opencontainers.image.version` labels to `3.5.25-r1` in the Dockerfile.
* Changed the download URL and file operations to use etcd version 3.5.25 instead of 3.5.23, ensuring the correct binaries are installed.
* Updated the `APP_VERSION` environment variable to `3.5.25` for consistency with the new etcd version.